### PR TITLE
Load database credentials from environment or properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ Flappy Bird Duo is a multiplayer version of the original Flappy Bird game. Playe
 ## Dependencies
 
 Install Latest [Java](https://www.java.com/download/ie_manual.jsp)
+
+## Database Configuration
+
+The game reads database connection details from the environment. Set the
+following variables before running the application:
+
+- `DB_URL` – JDBC URL of the database
+- `DB_USERNAME` – database user name
+- `DB_PASSWORD` – database user password
+
+As an alternative, you may place a `db.properties` file on the classpath
+containing the same keys.

--- a/app/src/main/java/com/joshiminh/flappybird/database/Database.java
+++ b/app/src/main/java/com/joshiminh/flappybird/database/Database.java
@@ -1,14 +1,60 @@
 package com.joshiminh.flappybird.database;
+
+import java.io.IOException;
+import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Properties;
 
+/**
+ * Utility class for creating database connections.
+ *
+ * <p>The connection details are loaded from environment variables or, if not
+ * present, from a {@code db.properties} file on the classpath. The expected
+ * keys are {@code DB_URL}, {@code DB_USERNAME} and {@code DB_PASSWORD}.</p>
+ */
 public class Database {
-    private static final String URL = "jdbc:mysql://f5-9w.h.filess.io:3307/FlappyBird_everyfive";
-    private static final String USERNAME = "FlappyBird_everyfive";
-    private static final String PASSWORD = "056275ab3f3cb63acb751f882280ee8b10898612";
+
+    private static String url;
+    private static String username;
+    private static String password;
+
+    private static void loadConfig() {
+        if (url != null && username != null && password != null) {
+            return;
+        }
+
+        url = getConfig("DB_URL");
+        username = getConfig("DB_USERNAME");
+        password = getConfig("DB_PASSWORD");
+    }
+
+    private static String getConfig(String key) {
+        String value = System.getenv(key);
+        if (value != null && !value.isEmpty()) {
+            return value;
+        }
+
+        try (InputStream in = Database.class.getClassLoader().getResourceAsStream("db.properties")) {
+            if (in != null) {
+                Properties props = new Properties();
+                props.load(in);
+                value = props.getProperty(key);
+                if (value != null && !value.isEmpty()) {
+                    return value;
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load database configuration", e);
+        }
+
+        throw new IllegalStateException("Missing configuration for " + key);
+    }
 
     public static Connection getConnection() throws SQLException {
-        return DriverManager.getConnection(URL, USERNAME, PASSWORD);
+        loadConfig();
+        return DriverManager.getConnection(url, username, password);
     }
 }
+


### PR DESCRIPTION
## Summary
- Load DB URL, username, and password from `DB_URL`, `DB_USERNAME`, and `DB_PASSWORD` environment variables with an optional `db.properties` fallback.
- Document required database configuration variables and optional properties file in README.

## Testing
- ⚠️ `sh ./gradlew test` *(failed: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68b11294459883308e49ddb52d967520