### PR TITLE
Load themes from manifest

### DIFF
--- a/app/src/main/resources/themes/themes.json
+++ b/app/src/main/resources/themes/themes.json
@@ -1,0 +1,6 @@
+[
+  "Original",
+  "9-11",
+  "Red Night",
+  "Under Water"
+]


### PR DESCRIPTION
## Summary
- Store available themes in `themes.json` under resources
- Load theme list at launch using `ResourceUtil`
- Parse manifest with null checks and choose default theme from list

## Testing
- `javac $(find app/src/main/java -name '*.java')`
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b112a77cb48330a19c2dcadb603357